### PR TITLE
Task A: Make InsurancePolicy.EndDate required and update seed data

### DIFF
--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -19,6 +19,10 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             .Property(p => p.StartDate)
             .IsRequired();
 
+        modelBuilder.Entity<InsurancePolicy>()
+            .Property(p => p.EndDate)
+            .IsRequired();
+
         // EndDate intentionally left nullable for a later task
     }
 }
@@ -40,9 +44,9 @@ public static class SeedData
         db.SaveChanges();
 
         db.Policies.AddRange(
-            new InsurancePolicy { CarId = car1.Id, Provider = "Allianz", StartDate = new DateOnly(2024,1,1), EndDate = new DateOnly(2024,12,31) },
-            new InsurancePolicy { CarId = car1.Id, Provider = "Groupama", StartDate = new DateOnly(2025,1,1), EndDate = null }, // open-ended on purpose
-            new InsurancePolicy { CarId = car2.Id, Provider = "Allianz", StartDate = new DateOnly(2025,3,1), EndDate = new DateOnly(2025,9,30) }
+            new InsurancePolicy { CarId = car1.Id, Provider = "Allianz", StartDate = new DateOnly(2024, 1, 1), EndDate = new DateOnly(2024, 12, 31) },
+            new InsurancePolicy { CarId = car1.Id, Provider = "Groupama", StartDate = new DateOnly(2025, 1, 1), EndDate = new DateOnly(2025, 10, 10) },
+            new InsurancePolicy { CarId = car2.Id, Provider = "Allianz", StartDate = new DateOnly(2025, 3, 1), EndDate = new DateOnly(2025, 9, 30) }
         );
         db.SaveChanges();
     }

--- a/Models/InsurancePolicy.cs
+++ b/Models/InsurancePolicy.cs
@@ -9,5 +9,5 @@ public class InsurancePolicy
 
     public string? Provider { get; set; }
     public DateOnly StartDate { get; set; }
-    public DateOnly? EndDate { get; set; } // intentionally nullable; will be enforced later
+    public DateOnly EndDate { get; set; } // intentionally nullable; will be enforced later -> checked
 }


### PR DESCRIPTION
1. Model – In InsurancePolicy.cs, made EndDate non-nullable 
2. DbContext – In AppDbContext.cs, configured EF Core to require EndDate at the database level using modelbuilder
3. Seed Data – Updated all insurance policies in SeedData to have a valid EndDate, removing any null values.